### PR TITLE
feat: add option to disable internal send and receive spans

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py
@@ -185,6 +185,11 @@ will replace the value of headers such as ``session-id`` and ``set-cookie`` with
 Note:
     The environment variable names used to capture HTTP headers are still experimental, and thus are subject to change.
 
+Internal HTTP spans
+*****************************
+Internal HTTP send and receive spans are added by default. These can optionally be excluded by setting the boolean environment variables
+``OTEL_PYTHON_ASGI_EXCLUDE_SEND_SPAN`` and ``OTEL_PYTHON_ASGI_EXCLUDE_RECEIVE_SPAN`` to ``true``.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/environment_variables.py
+++ b/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/environment_variables.py
@@ -1,0 +1,24 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Exclude the http send span from the tracing feature in Python.
+"""
+
+OTEL_PYTHON_ASGI_EXCLUDE_SEND_SPAN = "OTEL_PYTHON_ASGI_EXCLUDE_SEND_SPAN"
+
+"""
+Exclude the http receive span from the tracing feature in Python.
+"""
+OTEL_PYTHON_ASGI_EXCLUDE_RECEIVE_SPAN = "OTEL_PYTHON_ASGI_EXCLUDE_RECEIVE_SPAN"


### PR DESCRIPTION
# Description

This PR addresses the issue where it is not possible to disable internal HTTP send and receive spans. For many members of the community these do not provide any value and only add noise to the traces. Other mechanisms of filtering them out, such as wrapping span processors or exporters are clunky. 

Providing environment variables, namely: `OTEL_PYTHON_ASGI_EXCLUDE_SEND_SPAN` and `OTEL_PYTHON_ASGI_EXCLUDE_RECEIVE_SPAN` allows users to disable one or both of these with no additional code.

Fixes #831

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] TestAsgiApplication.test_exclude_internal_spans added to test logic
- [X Integration tests performed manually using the environment variables

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
